### PR TITLE
Allow thrown weapons to use ranged prefixes

### DIFF
--- a/HEROsModServices/PrefixScraper.cs
+++ b/HEROsModServices/PrefixScraper.cs
@@ -730,7 +730,7 @@ namespace HEROsMod.HEROsModServices
 		//add to Terraria.Item.Prefix
 		internal static bool RangedPrefix(Item item)
 		{
-			return item.modItem != null && GeneralPrefix(item) && item.ranged;
+			return item.modItem != null && GeneralPrefix(item) && (item.ranged || item.thrown);
 		}
 
 		//add to Terraria.Item.Prefix


### PR DESCRIPTION
This is consistent with what [ItemLoader](https://github.com/tModLoader/tModLoader/commit/8ba04c2a5f6045844301b4b0280bde9b1173c2ca) does.

Closes #31.