### PR TITLE
Add mod.Call for custom modded categories to the Item Browser

### DIFF
--- a/HEROsMod.cs
+++ b/HEROsMod.cs
@@ -22,6 +22,7 @@ namespace HEROsMod
 	{
 		public static HEROsMod instance;
 		internal static Dictionary<string, ModTranslation> translations; // reference to private field.
+		internal List<UIKit.UIComponents.ModCategory> modCategories;
 		internal Dictionary<string, Action<bool>> crossModGroupUpdated = new Dictionary<string, Action<bool>>();
 
 		public override void Load()
@@ -39,6 +40,8 @@ namespace HEROsMod
 				FieldInfo translationsField = typeof(Mod).GetField("translations", BindingFlags.Instance | BindingFlags.NonPublic);
 				translations = (Dictionary<string, ModTranslation>)translationsField.GetValue(this);
 				//LoadTranslations();
+
+				modCategories = new List<UIKit.UIComponents.ModCategory>();
 
 				//	AddGlobalItem("HEROsModGlobalItem", new HEROsModGlobalItem());
 				// AddPlayer("HEROsModModPlayer", new HEROsModModPlayer());
@@ -122,6 +125,7 @@ namespace HEROsMod
 			ServiceController = null;
 			TimeWeatherControlHotbar.Unload();
 			ModUtils.previousInventoryItems = null;
+			modCategories = null;
 			translations = null;
 			instance = null;
 		}
@@ -367,6 +371,16 @@ namespace HEROsMod
 						args[3] as Action<bool>
 					);
 					ModUtils.DebugText("...Permission Added");
+				}
+				else if (message == "AddItemCategory")
+				{
+					ModUtils.DebugText("Item Category Adding...");
+					string sortName = args[1] as string;
+					string parentName = args[2] as string;
+					Predicate<Item> belongs = args[3] as Predicate<Item>;
+					if (!Main.dedServ)
+						modCategories.Add(new UIKit.UIComponents.ModCategory(sortName, parentName, belongs));
+					ModUtils.DebugText("...Item Category Added");
 				}
 				else if (message == "HasPermission")
 				{

--- a/UIKit/UIComponents/ItemBrowser.cs
+++ b/UIKit/UIComponents/ItemBrowser.cs
@@ -619,6 +619,26 @@ namespace HEROsMod.UIKit.UIComponents
 				new Category("Other", x=>false),
 			};
 
+			List<Category> categoryList = new List<Category>(Categories);
+			foreach (var modCallCategory in HEROsMod.instance.modCategories)
+			{
+				if (string.IsNullOrEmpty(modCallCategory.Parent))
+				{
+					categoryList.Insert(categoryList.Count - 2, new Category(modCallCategory.Name, modCallCategory.belongs, true));
+				}
+				else
+				{
+					foreach (var item in categoryList)
+					{
+						if (item.Name == modCallCategory.Parent)
+						{
+							item.SubCategories.Add(new Category(modCallCategory.Name, modCallCategory.belongs, true));
+						}
+					}
+				}
+			}
+			Categories = categoryList.ToArray();
+
 			foreach (var parent in Categories)
 			{
 				foreach (var sub in parent.SubCategories)
@@ -756,6 +776,21 @@ namespace HEROsMod.UIKit.UIComponents
 	//	public Predicate<Item> filter;
 	//	internal UIImage button;
 	//}
+
+	// Represents a requested Category
+	internal class ModCategory
+	{
+		internal Predicate<Item> belongs;
+
+		internal string Name { get; private set; }
+		internal string Parent { get; private set; }
+		public ModCategory(string name, string parent, Predicate<Item> belongs)
+		{
+			Name = name;
+			Parent = parent;
+			this.belongs = belongs;
+		}
+	}
 
 	public class Category
 	{


### PR DESCRIPTION
Similarly to the Recipe Browser mod, adds a `Category` `mod.Call` so other mods can register their own items into a (sub)category. (Had to write it verbose as `UIKit.UIComponents.ModCategory` because `using HEROsMod.UIKit.UIComponents;` caused two `ItemBrowser` classes to collide and I didn't want to introduce any changes in places not relevant to the PR feature. I also had to temporarily convert the Categories array into a list to perform insertion easier.