### PR TITLE
add chat color customizability to groups

### DIFF
--- a/HEROsMod.cs
+++ b/HEROsMod.cs
@@ -142,8 +142,6 @@ namespace HEROsMod
 			reader.BaseStream.Position = savedPosition;
 
 			Color chatColor = Network.Players[senderPlayerId].Group?.Color ?? new Color(255, 255, 255);
-			// Try to solve backfilling issue (all existing groups will be (0,0,0,0)). Black chat color is hard to read anyway.
-			if (chatColor.Equals(new Color(0, 0, 0, 0))) chatColor = new Color(255, 255, 255);
 			Terraria.Net.NetPacket packet = Terraria.GameContent.NetModules.NetTextModule.SerializeServerMessage(NetworkText.FromLiteral(message.Text), chatColor, (byte)senderPlayerId);
 			Terraria.Net.NetManager.Instance.Broadcast(packet);
 

--- a/HEROsMod.cs
+++ b/HEROsMod.cs
@@ -1,4 +1,5 @@
-﻿using HEROsMod.HEROsModNetwork;
+﻿using On.Terraria.GameContent.NetModules;
+using HEROsMod.HEROsModNetwork;
 using HEROsMod.HEROsModServices;
 using HEROsMod.UIKit;
 using Microsoft.Xna.Framework;
@@ -9,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Terraria;
+using Terraria.Chat;
 using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.UI;
@@ -67,6 +69,8 @@ namespace HEROsMod
 			{
 				ModUtils.DebugText("Load:\n" + e.Message + "\n" + e.StackTrace + "\n");
 			}
+			// Intercept DeserializeAsServer method
+			NetTextModule.DeserializeAsServer += NetTextModule_DeserializeAsServer;
 		}
 
 		internal static string HeroText(string key)
@@ -128,6 +132,22 @@ namespace HEROsMod
 			modCategories = null;
 			translations = null;
 			instance = null;
+			NetTextModule.DeserializeAsServer -= NetTextModule_DeserializeAsServer;
+		}
+		
+		private bool NetTextModule_DeserializeAsServer(NetTextModule.orig_DeserializeAsServer orig, Terraria.GameContent.NetModules.NetTextModule self, BinaryReader reader, int senderPlayerId)
+		{
+			long savedPosition = reader.BaseStream.Position;
+			ChatMessage message = ChatMessage.Deserialize(reader);
+			reader.BaseStream.Position = savedPosition;
+
+			Color chatColor = Network.Players[senderPlayerId].Group?.Color ?? new Color(255, 255, 255);
+			// Try to solve backfilling issue (all existing groups will be (0,0,0,0)). Black chat color is hard to read anyway.
+			if (chatColor.Equals(new Color(0, 0, 0, 0))) chatColor = new Color(255, 255, 255);
+			Terraria.Net.NetPacket packet = Terraria.GameContent.NetModules.NetTextModule.SerializeServerMessage(NetworkText.FromLiteral(message.Text), chatColor, (byte)senderPlayerId);
+			Terraria.Net.NetManager.Instance.Broadcast(packet);
+
+			return true;
 		}
 
 		public override void PostSetupContent()

--- a/HEROsModNetwork/DatabaseController.cs
+++ b/HEROsModNetwork/DatabaseController.cs
@@ -38,6 +38,7 @@ namespace HEROsMod.HEROsModNetwork
 	{
 		public int ID;
 		public string name;
+		public Color color;
 
 		//public byte[] permissions;
 		public string[] permissions;
@@ -455,7 +456,7 @@ namespace HEROsMod.HEROsModNetwork
 		public static void AddGroup(ref Group group)
 		{
 			int newid = GetAvailableGroupID();
-			DatabaseGroup newGroup = new DatabaseGroup() { name = group.Name, ID = newid };
+			DatabaseGroup newGroup = new DatabaseGroup() { name = group.Name, ID = newid, color = group.Color };
 			database.groups.Add(newGroup);
 
 			group.ID = newid;
@@ -486,6 +487,7 @@ namespace HEROsMod.HEROsModNetwork
 			if (g != null)
 			{
 				g.permissions = group.Permissions.Where(x => x.Value).Select(x => x.Key).ToArray();//group.ExportPermissions();
+				g.color = group.Color;
 			}
 			SaveSetting(jsonDatabaseFilename);
 		}
@@ -497,6 +499,7 @@ namespace HEROsMod.HEROsModNetwork
 			{
 				Group group = new Group(dbGroup.name);
 				group.ID = dbGroup.ID;
+				group.Color = dbGroup.color;
 				group.ImportPermissions(dbGroup.permissions);
 				result.Add(group);
 			}

--- a/HEROsModNetwork/DatabaseController.cs
+++ b/HEROsModNetwork/DatabaseController.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using Terraria;
@@ -38,6 +39,8 @@ namespace HEROsMod.HEROsModNetwork
 	{
 		public int ID;
 		public string name;
+		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+		[DefaultValue(typeof(Color), "255, 255, 255, 255")]
 		public Color color;
 
 		//public byte[] permissions;

--- a/HEROsModNetwork/Group.cs
+++ b/HEROsModNetwork/Group.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Xna.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -62,6 +63,8 @@ namespace HEROsMod.HEROsModNetwork
 			get { return _isAdmin; }
 			set { _isAdmin = value; }
 		}
+		
+		public Color Color { get; set; }
 
 		public Group(string name)
 		{
@@ -78,6 +81,7 @@ namespace HEROsMod.HEROsModNetwork
 			{
 				Network.DefaultGroup = this;
 			}
+			this.Color = new Color(255, 255, 255);
 		}
 
 		public bool HasPermission(string permissionName)

--- a/HEROsModNetwork/LoginService.cs
+++ b/HEROsModNetwork/LoginService.cs
@@ -345,6 +345,7 @@ namespace HEROsMod.HEROsModNetwork
 				{
 					Writer.Write(Network.Groups[i].Name);
 					Writer.Write(Network.Groups[i].ID);
+					Writer.WriteRGB(Network.Groups[i].Color);
 					byte[] permissions = Network.Groups[i].ExportPermissions();
 					Writer.Write(permissions.Length);
 					Writer.Write(permissions);
@@ -364,6 +365,7 @@ namespace HEROsMod.HEROsModNetwork
 					string groupName = reader.ReadString();
 					Group group = new Group(groupName);
 					group.ID = reader.ReadInt32();
+					group.Color = reader.ReadRGB();
 					int permissionsLength = reader.ReadInt32();
 					group.ImportPermissions(reader.ReadBytes(permissionsLength));
 					Network.Groups.Add(group);
@@ -395,6 +397,7 @@ namespace HEROsMod.HEROsModNetwork
 				Writer.Write(group.Name);
 				Writer.Write(group.ID);
 				Writer.Write(group.IsAdmin);
+				Writer.WriteRGB(group.Color);
 				byte[] permissions = group.ExportPermissions();
 				//if(CTF.CaptureTheFlag.GameInProgress)
 				//{
@@ -420,6 +423,7 @@ namespace HEROsMod.HEROsModNetwork
 				group.IsAdmin = true;
 				//group.MakeAdmin();
 			}
+			group.Color = reader.ReadRGB();
 			int permissionsLength = reader.ReadInt32();
 			group.ImportPermissions(reader.ReadBytes(permissionsLength));
 
@@ -435,6 +439,7 @@ namespace HEROsMod.HEROsModNetwork
 			byte[] permissions = group.ExportPermissions();
 			Writer.Write(permissions.Length);
 			Writer.Write(permissions);
+			Writer.WriteRGB(group.Color);
 			Network.SendDataToServer();
 		}
 
@@ -447,6 +452,7 @@ namespace HEROsMod.HEROsModNetwork
 				Group group = Network.GetGroupByID(id);
 				int permissionsLength = reader.ReadInt32();
 				group.ImportPermissions(reader.ReadBytes(permissionsLength));
+				group.Color = reader.ReadRGB();
 				DatabaseController.SetGroupPermissions(group);
 
 				for (int i = 0; i < Network.Players.Length; i++)

--- a/HEROsModServices/GroupInspector.cs
+++ b/HEROsModServices/GroupInspector.cs
@@ -75,6 +75,7 @@ namespace HEROsMod.HEROsModServices
 
 		//Group group;
 		private UIDropdown dropdown = new UIDropdown();
+		private UIColorPicker colorPicker = new UIKit.UIColorPicker();
 
 		private UIScrollView checkboxContainer = new UIScrollView();
 
@@ -105,8 +106,10 @@ namespace HEROsMod.HEROsModServices
 			dropdown.X = label.X + label.Width + 4;
 			dropdown.Y = label.Y;
 			dropdown.Width = 200;
+			colorPicker.X = dropdown.X + dropdown.Width + spacing;
+			colorPicker.Y = dropdown.Y;
 			checkboxContainer.X = spacing;
-			checkboxContainer.Y = dropdown.Y + dropdown.Height + spacing;
+			checkboxContainer.Y = colorPicker.Y + colorPicker.Height + spacing;
 			checkboxContainer.Width = this.Width - spacing * 2;
 			checkboxContainer.Height = 150;
 			AddChild(checkboxContainer);
@@ -137,6 +140,7 @@ namespace HEROsMod.HEROsModServices
 			AddChild(bNew);
 			AddChild(bDelete);
 			AddChild(dropdown);
+			AddChild(colorPicker);
 
 			this.Height = bApply.Position.Y + bApply.Height + spacing;
 			this.CenterToParent();
@@ -168,6 +172,7 @@ namespace HEROsMod.HEROsModServices
 		{
 			HEROsModNetwork.Group group = new HEROsModNetwork.Group(dropdown.GetItem(dropdown.SelectedItem));
 			group.ID = HEROsModNetwork.Network.Groups[dropdown.SelectedItem].ID;
+			group.Color = colorPicker.Color;
 			group.ImportPermissions(ExportPermissions());
 			HEROsModNetwork.LoginService.RequestSetGroupPermissions(group);
 		}
@@ -202,6 +207,7 @@ namespace HEROsMod.HEROsModServices
 			}
 			if (checkboxContainer.ChildCount > 0)
 				checkboxContainer.ContentHeight = checkboxContainer.GetLastChild().Y + checkboxContainer.GetLastChild().Height + spacing;
+			colorPicker.Color = HEROsModNetwork.Network.Groups[dropdown.SelectedItem].Color;
 		}
 
 		private byte[] ExportPermissions()


### PR DESCRIPTION
Hi, I would like to add this feature! It partially addresses #38. I may try to add prefixes in the future.

I have tried this alongside TCR-TerrariaChatRelay which uses the same method to intercept chat messages, and it works fine.

I wasn't able to set a chat color for Admin because it seems that it's created on mod load rather than stored in the database. I didn't really need it now though so I decided I'll leave it as is and maybe try again in the future.

![20220117010427_1](https://user-images.githubusercontent.com/4967258/149719035-3442fd08-06fa-4913-a8bb-27d2fc29f272.jpg)
![20220117013034_1](https://user-images.githubusercontent.com/4967258/149719037-c797166b-96ec-4cd1-af8c-873bc06d1b8d.jpg)