### PR TITLE
Add RegisterGodModeCallback mod call

### DIFF
--- a/HEROsMod.cs
+++ b/HEROsMod.cs
@@ -126,6 +126,7 @@ namespace HEROsMod
 			TimeWeatherControlHotbar.Unload();
 			ModUtils.previousInventoryItems = null;
 			modCategories = null;
+			GodModeService.ClearGodModeCallback();
 			translations = null;
 			instance = null;
 		}
@@ -139,6 +140,15 @@ namespace HEROsMod
 					service.PostSetupContent();
 				}
 			}
+		}
+
+		public override void PreUpdateEntities()
+		{
+			//Handle callbacks here as this is called on all sides
+			//May need to filter allside vs clientside callbacks
+
+			//Only godmode for now
+			GodModeService.InvokeGodModeCallback();
 		}
 
 		public override void PostDrawFullscreenMap(ref string mouseText)
@@ -398,6 +408,13 @@ namespace HEROsMod
 						if(!ServiceHotbar.Collapsed) // sub hotbars
 							ServiceHotbar.collapseArrow_onLeftClick(null, null);
 					}
+				}
+				else if (message == "RegisterGodModeCallback")
+				{
+					ModUtils.DebugText("God Mode Callback Adding...");
+					Action<bool> callback = args[1] as Action<bool>;
+					GodModeService.GodModeCallback += callback;
+					ModUtils.DebugText("...God Mode Callback Added");
 				}
 				else
 				{

--- a/HEROsModServices/GodModeService.cs
+++ b/HEROsModServices/GodModeService.cs
@@ -10,6 +10,8 @@ namespace HEROsMod.HEROsModServices
 
 		private static event GodModeToggledEvent GodModeToggled;
 
+		internal static event Action<bool> GodModeCallback;
+
 		private static bool _enabled = false;
 
 		public static bool Enabled
@@ -23,6 +25,16 @@ namespace HEROsMod.HEROsModServices
 				}
 				_enabled = value;
 			}
+		}
+
+		internal static void ClearGodModeCallback()
+		{
+			GodModeCallback = null;
+		}
+
+		internal static void InvokeGodModeCallback()
+		{
+			GodModeCallback?.Invoke(Enabled);
 		}
 
 		public GodModeService()


### PR DESCRIPTION
Need to decide between calling each tick and a toggle approach. If a toggle approach is used, need to make sure it is invoked properly if mods are changed, switching between MP/SP, and changing roles/accounts.

Sample usage
```cs
private static void DoHEROsModSupport()
{
    Mod HEROsMod = ModLoader.GetMod("HEROsMod");
    if (HEROsMod != null && HEROsMod.Version >= new Version(0, 3, 6, 3)) //Version todo, current is 0.3.6.2
    {
        HEROsMod.Call("RegisterGodModeCallback", (Action<bool>)HEROsModGodMode);
    }
}

private static void HEROsModGodMode(bool enabled)
{
    ResourcePlayer.godMode = enabled;
}

public class ResourcePlayer : ModPlayer
{
    public static bool godMode; //Set to false in unload

    public const int defaultResourceMax = 10;

    public int resourceMax = defaultResourceMax;
    public int resource = defaultResourceMax;

    public override void PreUpdate()
    {
        if (godMode)
        {
            resource = resourceMax;
        }
    }
}
```