### PR TITLE
Add player death check on logout request to prevent log out respawn abuse

### DIFF
--- a/HEROsModServices/Login.cs
+++ b/HEROsModServices/Login.cs
@@ -65,7 +65,10 @@ namespace HEROsMod.HEROsModServices
 		{
 			if (LoggedIn)
 			{
-				HEROsModNetwork.LoginService.RequestLogout();
+				if (!Main.LocalPlayer.dead)
+				{
+					HEROsModNetwork.LoginService.RequestLogout();
+				}
 			}
 			else
 			{

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
 author = HERO, jopojelly, Matt Thompson, Panini
-version = 0.4.14.2
+version = 0.4.14.3
 versionScheme = ?.?.Fix.Quickfix
 displayName = HERO's Mod
 homepage = http://forums.terraria.org/index.php?threads/heros-mod-creative-mode-server-management-and-over-25-tools-1-3-1-1-compatible.44650/


### PR DESCRIPTION
This is just a quick fix for the issue. My friends keep abusing this, and it ruins the balance I set up for them.