### PR TITLE
Improve mob spawning for NPC's with netIDs

### DIFF
--- a/HEROsModServices/MobSpawner.cs
+++ b/HEROsModServices/MobSpawner.cs
@@ -769,11 +769,8 @@ namespace HEROsMod.HEROsModServices
 				}
 			}
 
-			int index = NPC.NewNPC(NPC.GetSource_NaturalSpawn(), (int)player.position.X, (int)player.position.Y, Type);
-			if (NetID < 0)
-			{
-				Main.npc[index].SetDefaults(NetID);
-			}
+			int spawnType = NetID < 0 ? NetID : Type;
+			int index = NPC.NewNPC(NPC.GetSource_NaturalSpawn(), (int)player.position.X + (200 * player.direction), (int)player.position.Y - 10, spawnType);
 		}
 	}
 


### PR DESCRIPTION
Currently, spawning an NPC with a netID causes SetDefaults to be fired twice.

Generally this is not a big deal, but in some cases, such as mods trying to modify stats only for a given netID and not every NPC that shares the type, this causes issues.

Simply spawning the NPC using the netID resolves this issue.

This PR also introduces a spawning offset so NPCs aren't spawned directly on top of the player.