### PR TITLE
fix: add Old Shaking Chest

### DIFF
--- a/HEROsModServices/MobSpawner.cs
+++ b/HEROsModServices/MobSpawner.cs
@@ -525,8 +525,8 @@ namespace HEROsMod.HEROsModServices
 
 			RemoveNPCTypeFromList(NPCID.WallofFlesh);
 
-			NPC wof = new NPC();
-			wof.SetDefaults(113);
+			NPC wof = new();
+			wof.SetDefaults(NPCID.WallofFlesh);
 			npcList.Add(new WallOfFlesh(wof));
 
 			NPC oldShakingChest = new();
@@ -850,7 +850,7 @@ namespace HEROsMod.HEROsModServices
 			}
 		IL_162:
 			num3 = num5 * 16;
-			int num7 = NPC.NewNPC(NPC.GetSource_NaturalSpawn(), num2, num3, 113, 0);
+			int num7 = NPC.NewNPC(NPC.GetSource_NaturalSpawn(), num2, num3, NPCID.WallofFlesh, 0);
 			if (Main.netMode == NetmodeID.SinglePlayer)
 			{
 				Main.NewText(Language.GetTextValue("Announcement.HasAwoken", Main.npc[num7].TypeName), 175, 75, 255);

--- a/HEROsModServices/MobSpawner.cs
+++ b/HEROsModServices/MobSpawner.cs
@@ -508,9 +508,10 @@ namespace HEROsMod.HEROsModServices
 			npcList = new List<NPCStats>();
 			NPC npc;
 			npc = new NPC();
+			int[] showDespiteNPCBestiaryDrawModifiersHide = [NPCID.BoundTownSlimeOld];
 			for (int i = 1; i < TextureAssets.Npc.Length; i++)
 			{
-				if (!NPCID.Sets.NPCBestiaryDrawOffset.TryGetValue(i, out var value) || !value.Hide)
+				if (!NPCID.Sets.NPCBestiaryDrawOffset.TryGetValue(i, out var value) || !value.Hide || showDespiteNPCBestiaryDrawModifiersHide.Contains(i))
 				{
 					npc.SetDefaults(i);
 					npcList.Add(new NPCStats(npc));
@@ -528,10 +529,6 @@ namespace HEROsMod.HEROsModServices
 			NPC wof = new();
 			wof.SetDefaults(NPCID.WallofFlesh);
 			npcList.Add(new WallOfFlesh(wof));
-
-			NPC oldShakingChest = new();
-			oldShakingChest.SetDefaults(NPCID.BoundTownSlimeOld);
-			npcList.Add(new NPCStats(oldShakingChest));
 			
 			npc = null;
 			npcList = npcList.OrderBy(n => n.Name).ToList();

--- a/HEROsModServices/MobSpawner.cs
+++ b/HEROsModServices/MobSpawner.cs
@@ -529,6 +529,10 @@ namespace HEROsMod.HEROsModServices
 			wof.SetDefaults(113);
 			npcList.Add(new WallOfFlesh(wof));
 
+			NPC oldShakingChest = new();
+			oldShakingChest.SetDefaults(NPCID.BoundTownSlimeOld);
+			npcList.Add(new NPCStats(oldShakingChest));
+			
 			npc = null;
 			npcList = npcList.OrderBy(n => n.Name).ToList();
 


### PR DESCRIPTION
## Summary
Add ability to spawn Old Shaking Chest in the Mob Spawner window.

## Changes
- Replace hardcoded NPC type `113` with `NPCID.WallofFlesh`.
- Add Old Shaking Chest to the NPC list via `NPCID.BoundTownSlimeOld`.

### Fixes #166