### PR TITLE
fix: correct portrait for Deerclops and Queen Slime

### DIFF
--- a/HEROsModServices/MobSpawner.cs
+++ b/HEROsModServices/MobSpawner.cs
@@ -567,7 +567,29 @@ namespace HEROsMod.HEROsModServices
 			CurrentNPC = npc;
 			ModUtils.LoadNPC(npc.Type, immediate: true);
 			mobImage.Texture = TextureAssets.Npc[npc.Type];
-			mobImage.SourceRectangle = new Rectangle(0, 0, (int)mobImage.Texture.Value.Width, (int)mobImage.Texture.Value.Height / Main.npcFrameCount[npc.Type]);
+			mobImage.SourceRectangle = npc.Type switch
+			{
+				NPCID.Deerclops => new Rectangle(
+					0,
+					0,
+					mobImage.Texture.Value.Width / 5,
+					mobImage.Texture.Value.Height / 5
+				),
+
+				NPCID.QueenSlimeBoss => new Rectangle(
+					0,
+					0,
+					mobImage.Texture.Value.Width / 2,
+					mobImage.Texture.Value.Height / 16
+				),
+
+				_ => new Rectangle(
+					0,
+					0,
+					mobImage.Texture.Value.Width,
+					mobImage.Texture.Value.Height / Main.npcFrameCount[npc.Type]
+				),
+			};
 			mobImage.ForegroundColor = CurrentNPC.AlphaColor;
 			AddChild(mobImage);
 


### PR DESCRIPTION
## Summary
Add manual spritesheet cropping for Deerclops and Queen Slime to render their portraits correctly.

## Changes
- Introduce a switch in `SetMobType` with overrides for `Deerclops` and `QueenSlimeBoss` to set `mobImage.SourceRectangle`.
- Keep the existing default `SourceRectangle` calculation for all other NPCs.

### Fixes #157