### PR TITLE
fix: skip `itemTime` forcing for channeling tools (e.g. drills)

### DIFF
--- a/HEROsModServices/InfiniteReach.cs
+++ b/HEROsModServices/InfiniteReach.cs
@@ -104,6 +104,10 @@ namespace HEROsMod.HEROsModServices
 
 				// Works with: Place tiles, walls. Axe, Hammer, Pick.
 				Item selected = player.inventory[player.selectedItem];
+				if (selected.channel)
+				{
+					return;
+				}
 				if (selected.createTile >= TileID.Dirt || selected.createWall >= 0 || selected.pick > 0 || selected.axe > 0 || selected.hammer > 0)
 				{
 					// TODO, hammering tile destorys walls too??


### PR DESCRIPTION
## Summary
Skip forcing `player.itemTime` for channeling tools (e.g. drills) when Infinite Reach is enabled, because interrupting use locked out further interaction with items and the UI.

## Changes
- Add an early return for `selected.channel` in `Update()` to avoid overriding `itemTime` for channeling tools.

### Fixes #155